### PR TITLE
Add Bom router and server for API getBmcMacAddrr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,7 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -37,7 +37,7 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 		os.Exit(1)
 	}
 }

--- a/internal/server/ginlogrus.go
+++ b/internal/server/ginlogrus.go
@@ -44,7 +44,7 @@ var timeFormat = "02/Jan/2006:15:04:05 -0700"
 func loggerMiddleware(logger logrus.FieldLogger, notLogged ...string) gin.HandlerFunc {
 	hostname, err := os.Hostname()
 	if err != nil {
-		hostname = "unknow"
+		hostname = "unknown"
 	}
 
 	var skip map[string]struct{}

--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -15,6 +15,9 @@ type Repository interface {
 	// GetBomInfoByAOCMacAddr gets bom object by AOCMacAddr.
 	GetBomInfoByAOCMacAddr(ctx context.Context, macAddr string) (*sservice.Bom, *sservice.ServerResponse, error)
 
+	// GetBomInfoByBMCMacAddr gets bom object by BMCMacAddr.
+	GetBomInfoByBMCMacAddr(ctx context.Context, macAddr string) (*sservice.Bom, *sservice.ServerResponse, error)
+
 	// BillOfMaterialsBatchUpload creates a bom on a server.
 	BillOfMaterialsBatchUpload(ctx context.Context, boms []sservice.Bom) (*sservice.ServerResponse, error)
 }

--- a/internal/store/mock/mock.go
+++ b/internal/store/mock/mock.go
@@ -65,3 +65,19 @@ func (mr *MockRepositoryMockRecorder) GetBomInfoByAOCMacAddr(ctx, macAddr interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBomInfoByAOCMacAddr", reflect.TypeOf((*MockRepository)(nil).GetBomInfoByAOCMacAddr), ctx, macAddr)
 }
+
+// GetBomInfoByBMCMacAddr mocks base method.
+func (m *MockRepository) GetBomInfoByBMCMacAddr(ctx context.Context, macAddr string) (*serverservice.Bom, *serverservice.ServerResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBomInfoByBMCMacAddr", ctx, macAddr)
+	ret0, _ := ret[0].(*serverservice.Bom)
+	ret1, _ := ret[1].(*serverservice.ServerResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBomInfoByBMCMacAddr indicates an expected call of GetBomInfoByBMCMacAddr.
+func (mr *MockRepositoryMockRecorder) GetBomInfoByBMCMacAddr(ctx, macAddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBomInfoByBMCMacAddr", reflect.TypeOf((*MockRepository)(nil).GetBomInfoByBMCMacAddr), ctx, macAddr)
+}

--- a/internal/store/serverservice.go
+++ b/internal/store/serverservice.go
@@ -120,3 +120,8 @@ func (s *Serverservice) BillOfMaterialsBatchUpload(ctx context.Context, boms []s
 func (s *Serverservice) GetBomInfoByAOCMacAddr(ctx context.Context, macAddr string) (*sservice.Bom, *sservice.ServerResponse, error) {
 	return s.client.GetBomInfoByAOCMacAddr(ctx, macAddr)
 }
+
+// GetBomInfoByBMCMacAddr will return the bom info object by the bmc mac address.
+func (s *Serverservice) GetBomInfoByBMCMacAddr(ctx context.Context, macAddr string) (*sservice.Bom, *sservice.ServerResponse, error) {
+	return s.client.GetBomInfoByBMCMacAddr(ctx, macAddr)
+}

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/metal-toolbox/hollow-bomservice/internal/parse"
+	"github.com/pkg/errors"
 	sservice "go.hollow.sh/serverservice/pkg/api/v1"
 )
 
@@ -34,7 +35,7 @@ func (r *Routes) billOfMaterialsBatchUpload(c *gin.Context) (int, *sservice.Serv
 func (r *Routes) getBomInfoByAOCMacAddr(c *gin.Context) (int, *sservice.ServerResponse) {
 	_, resp, err := r.repository.GetBomInfoByAOCMacAddr(c.Request.Context(), c.Param("aoc_mac_address"))
 	if err != nil {
-		return http.StatusBadRequest, nil
+		return http.StatusBadRequest, &sservice.ServerResponse{Error: (errors.Wrap(ErrServerServiceQuery, err.Error())).Error()}
 	}
 	return http.StatusOK, resp
 }
@@ -42,7 +43,7 @@ func (r *Routes) getBomInfoByAOCMacAddr(c *gin.Context) (int, *sservice.ServerRe
 func (r *Routes) getBomInfoByBMCMacAddr(c *gin.Context) (int, *sservice.ServerResponse) {
 	_, resp, err := r.repository.GetBomInfoByBMCMacAddr(c.Request.Context(), c.Param("bmc_mac_address"))
 	if err != nil {
-		return http.StatusBadRequest, nil
+		return http.StatusInternalServerError, &sservice.ServerResponse{Error: (errors.Wrap(ErrServerServiceQuery, err.Error())).Error()}
 	}
 	return http.StatusOK, resp
 }

--- a/pkg/api/v1/routes/handlers.go
+++ b/pkg/api/v1/routes/handlers.go
@@ -38,3 +38,11 @@ func (r *Routes) getBomInfoByAOCMacAddr(c *gin.Context) (int, *sservice.ServerRe
 	}
 	return http.StatusOK, resp
 }
+
+func (r *Routes) getBomInfoByBMCMacAddr(c *gin.Context) (int, *sservice.ServerResponse) {
+	_, resp, err := r.repository.GetBomInfoByBMCMacAddr(c.Request.Context(), c.Param("bmc_mac_address"))
+	if err != nil {
+		return http.StatusBadRequest, nil
+	}
+	return http.StatusOK, resp
+}

--- a/pkg/api/v1/routes/routes.go
+++ b/pkg/api/v1/routes/routes.go
@@ -124,6 +124,10 @@ func (r *Routes) Routes(g *gin.RouterGroup) {
 		bomService.GET("/aoc-mac-address/:aoc_mac_address",
 			r.composeAuthHandler(readScopes("aoc-mac-address")),
 			wrapAPICall(r.getBomInfoByAOCMacAddr))
+
+		bomService.GET("/bmc-mac-address/:bmc_mac_address",
+			r.composeAuthHandler(readScopes("bmc-mac-address")),
+			wrapAPICall(r.getBomInfoByBMCMacAddr))
 	}
 }
 


### PR DESCRIPTION
This is a follow up PR from https://github.com/metal-toolbox/hollow-bomservice/pull/2 for getBmcMacAddrr API

**Test**

- Tested with unit test
- Tested in local environment with the flow: curl -> bomservice -> serverservice -> crdb
- get: curl localhost:9003/api/v1/bomservice/bmc-mac-address/B1 -v

