### PR TITLE
[FS-977]Simplify the app name

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -7,7 +7,7 @@ type AppKind string
 type LogLevel string
 
 const (
-	AppName string = "hollow-bomservice"
+	AppName string = "bomservice"
 
 	// AppKindServer identifies a hollow bomservice.
 	AppKindServer AppKind = "hollow-bomservice-server"

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -10,7 +10,7 @@ const (
 	AppName string = "bomservice"
 
 	// AppKindServer identifies a hollow bomservice.
-	AppKindServer AppKind = "hollow-bomservice-server"
+	AppKindServer AppKind = "bomservice-server"
 
 	LogLevelInfo  LogLevel = "info"
 	LogLevelDebug LogLevel = "debug"


### PR DESCRIPTION
This PR is to simplify the app name for bom service which mocks `conditionorc`:
https://github.com/metal-toolbox/conditionorc/blob/6d0c0e86b8508e4ba82b5301137bfe3f197e4ec2/internal/model/model.go#L23

This will shorten the length of environment variables which make them easier to read.